### PR TITLE
Snapshots

### DIFF
--- a/src/components/vm/VmSnapshots.tsx
+++ b/src/components/vm/VmSnapshots.tsx
@@ -1,18 +1,11 @@
 import { useState, useEffect } from 'react';
-import { getVmSnapshots } from '../../services/virtualization';
+import { getVmSnapshots, deleteVmSnapshot } from '../../services/virtualization';
 import {
-    Card,
-    CardContent,
-    CardHeader,
-    Table,
-    TableBody,
-    TableCell,
-    TableContainer,
-    TableHead,
-    TableRow,
-    Paper,
-    IconButton,
-    Tooltip
+    Card, CardContent, CardHeader, Table, TableBody,
+    TableCell, TableContainer, TableHead, TableRow,
+    Paper, IconButton, Tooltip, Dialog, DialogTitle,
+    DialogContent, DialogContentText, DialogActions,
+    Button, Alert, Snackbar
 } from '@mui/material';
 import RestoreIcon from '@mui/icons-material/Restore';
 import DeleteIcon from '@mui/icons-material/Delete';
@@ -32,6 +25,15 @@ export default function VmSnapshots({ vmName }: VmSnapshotsProps) {
     }>>([]);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
+    const [deleteDialog, setDeleteDialog] = useState<{open: boolean, snapshot: string | null}>({
+        open: false,
+        snapshot: null
+    });
+    const [snackbar, setSnackbar] = useState<{open: boolean, message: string, severity: 'success' | 'error'}>({
+        open: false,
+        message: '',
+        severity: 'success'
+    });
 
     useEffect(() => {
         const fetchSnapshots = async () => {
@@ -53,54 +55,125 @@ export default function VmSnapshots({ vmName }: VmSnapshotsProps) {
         return new Date(parseInt(timestamp) * 1000).toLocaleString('de-DE');
     };
 
+    const handleDeleteClick = (snapshotName: string) => {
+        setDeleteDialog({
+            open: true,
+            snapshot: snapshotName
+        });
+    };
+
+    const handleDeleteConfirm = async () => {
+        if (!deleteDialog.snapshot) return;
+
+        try {
+            await deleteVmSnapshot(vmName, deleteDialog.snapshot);
+            setSnackbar({
+                open: true,
+                message: 'Snapshot erfolgreich gelöscht',
+                severity: 'success'
+            });
+            // Snapshot-Liste neu laden
+            const response = await getVmSnapshots(vmName);
+            setSnapshots(response.snapshots);
+        } catch (err) {
+            setSnackbar({
+                open: true,
+                message: err instanceof Error ? err.message : 'Fehler beim Löschen des Snapshots',
+                severity: 'error'
+            });
+        } finally {
+            setDeleteDialog({ open: false, snapshot: null });
+        }
+    };
+
     if (loading) return <div>Lade Snapshots...</div>;
     if (error) return <div>Fehler: {error}</div>;
 
     return (
-        <Card elevation={3}>
-            <CardHeader
-                title="VM Snapshots"
-                avatar={<PhotoCameraIcon color="primary" />}
-            />
-            <CardContent>
-                <TableContainer component={Paper}>
-                    <Table>
-                        <TableHead>
-                            <TableRow>
-                                <TableCell>Name</TableCell>
-                                <TableCell>Erstellt am</TableCell>
-                                <TableCell>Status</TableCell>
-                                <TableCell>Beschreibung</TableCell>
-                                <TableCell>Parent</TableCell>
-                                <TableCell>Aktionen</TableCell>
-                            </TableRow>
-                        </TableHead>
-                        <TableBody>
-                            {snapshots.map((snapshot) => (
-                                <TableRow key={snapshot.name}>
-                                    <TableCell>{snapshot.name}</TableCell>
-                                    <TableCell>{formatDate(snapshot.creationTime)}</TableCell>
-                                    <TableCell>{snapshot.state}</TableCell>
-                                    <TableCell>{snapshot.description || '-'}</TableCell>
-                                    <TableCell>{snapshot.parent || '-'}</TableCell>
-                                    <TableCell>
-                                        <Tooltip title="Wiederherstellen">
-                                            <IconButton>
-                                                <RestoreIcon />
-                                            </IconButton>
-                                        </Tooltip>
-                                        <Tooltip title="Löschen">
-                                            <IconButton color="error">
-                                                <DeleteIcon />
-                                            </IconButton>
-                                        </Tooltip>
-                                    </TableCell>
+        <>
+            <Card elevation={3}>
+                <CardHeader
+                    title="VM Snapshots"
+                    avatar={<PhotoCameraIcon color="primary" />}
+                />
+                <CardContent>
+                    <TableContainer component={Paper}>
+                        <Table>
+                            <TableHead>
+                                <TableRow>
+                                    <TableCell>Name</TableCell>
+                                    <TableCell>Erstellt am</TableCell>
+                                    <TableCell>Status</TableCell>
+                                    <TableCell>Beschreibung</TableCell>
+                                    <TableCell>Parent</TableCell>
+                                    <TableCell>Aktionen</TableCell>
                                 </TableRow>
-                            ))}
-                        </TableBody>
-                    </Table>
-                </TableContainer>
-            </CardContent>
-        </Card>
+                            </TableHead>
+                            <TableBody>
+                                {snapshots.map((snapshot) => (
+                                    <TableRow key={snapshot.name}>
+                                        <TableCell>{snapshot.name}</TableCell>
+                                        <TableCell>{formatDate(snapshot.creationTime)}</TableCell>
+                                        <TableCell>{snapshot.state}</TableCell>
+                                        <TableCell>{snapshot.description || '-'}</TableCell>
+                                        <TableCell>{snapshot.parent || '-'}</TableCell>
+                                        <TableCell>
+                                            <Tooltip title="Wiederherstellen">
+                                                <IconButton>
+                                                    <RestoreIcon />
+                                                </IconButton>
+                                            </Tooltip>
+                                            <Tooltip title="Löschen">
+                                                <IconButton 
+                                                    color="error"
+                                                    onClick={() => handleDeleteClick(snapshot.name)}
+                                                >
+                                                    <DeleteIcon />
+                                                </IconButton>
+                                            </Tooltip>
+                                        </TableCell>
+                                    </TableRow>
+                                ))}
+                            </TableBody>
+                        </Table>
+                    </TableContainer>
+                </CardContent>
+            </Card>
+
+            {/* Delete Confirmation Dialog */}
+            <Dialog
+                open={deleteDialog.open}
+                onClose={() => setDeleteDialog({ open: false, snapshot: null })}
+            >
+                <DialogTitle>Snapshot löschen</DialogTitle>
+                <DialogContent>
+                    <DialogContentText>
+                        Möchten Sie den Snapshot "{deleteDialog.snapshot}" wirklich löschen?
+                    </DialogContentText>
+                </DialogContent>
+                <DialogActions>
+                    <Button onClick={() => setDeleteDialog({ open: false, snapshot: null })}>
+                        Abbrechen
+                    </Button>
+                    <Button onClick={handleDeleteConfirm} color="error" variant="contained">
+                        Löschen
+                    </Button>
+                </DialogActions>
+            </Dialog>
+
+            {/* Status Snackbar */}
+            <Snackbar
+                open={snackbar.open}
+                autoHideDuration={6000}
+                onClose={() => setSnackbar(prev => ({ ...prev, open: false }))}
+            >
+                <Alert 
+                    severity={snackbar.severity}
+                    onClose={() => setSnackbar(prev => ({ ...prev, open: false }))}
+                >
+                    {snackbar.message}
+                </Alert>
+            </Snackbar>
+        </>
     );
 }

--- a/src/components/vm/VmSnapshots.tsx
+++ b/src/components/vm/VmSnapshots.tsx
@@ -1,0 +1,106 @@
+import { useState, useEffect } from 'react';
+import { getVmSnapshots } from '../../services/virtualization';
+import {
+    Card,
+    CardContent,
+    CardHeader,
+    Table,
+    TableBody,
+    TableCell,
+    TableContainer,
+    TableHead,
+    TableRow,
+    Paper,
+    IconButton,
+    Tooltip
+} from '@mui/material';
+import RestoreIcon from '@mui/icons-material/Restore';
+import DeleteIcon from '@mui/icons-material/Delete';
+import PhotoCameraIcon from '@mui/icons-material/PhotoCamera';
+
+interface VmSnapshotsProps {
+    vmName: string;
+}
+
+export default function VmSnapshots({ vmName }: VmSnapshotsProps) {
+    const [snapshots, setSnapshots] = useState<Array<{
+        name: string;
+        creationTime: string;
+        state: string;
+        description: string;
+        parent: string | null;
+    }>>([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+
+    useEffect(() => {
+        const fetchSnapshots = async () => {
+            try {
+                setLoading(true);
+                const response = await getVmSnapshots(vmName);
+                setSnapshots(response.snapshots);
+            } catch (err) {
+                setError(err instanceof Error ? err.message : 'Fehler beim Laden der Snapshots');
+            } finally {
+                setLoading(false);
+            }
+        };
+
+        fetchSnapshots();
+    }, [vmName]);
+
+    const formatDate = (timestamp: string) => {
+        return new Date(parseInt(timestamp) * 1000).toLocaleString('de-DE');
+    };
+
+    if (loading) return <div>Lade Snapshots...</div>;
+    if (error) return <div>Fehler: {error}</div>;
+
+    return (
+        <Card elevation={3}>
+            <CardHeader
+                title="VM Snapshots"
+                avatar={<PhotoCameraIcon color="primary" />}
+            />
+            <CardContent>
+                <TableContainer component={Paper}>
+                    <Table>
+                        <TableHead>
+                            <TableRow>
+                                <TableCell>Name</TableCell>
+                                <TableCell>Erstellt am</TableCell>
+                                <TableCell>Status</TableCell>
+                                <TableCell>Beschreibung</TableCell>
+                                <TableCell>Parent</TableCell>
+                                <TableCell>Aktionen</TableCell>
+                            </TableRow>
+                        </TableHead>
+                        <TableBody>
+                            {snapshots.map((snapshot) => (
+                                <TableRow key={snapshot.name}>
+                                    <TableCell>{snapshot.name}</TableCell>
+                                    <TableCell>{formatDate(snapshot.creationTime)}</TableCell>
+                                    <TableCell>{snapshot.state}</TableCell>
+                                    <TableCell>{snapshot.description || '-'}</TableCell>
+                                    <TableCell>{snapshot.parent || '-'}</TableCell>
+                                    <TableCell>
+                                        <Tooltip title="Wiederherstellen">
+                                            <IconButton>
+                                                <RestoreIcon />
+                                            </IconButton>
+                                        </Tooltip>
+                                        <Tooltip title="Löschen">
+                                            <IconButton color="error">
+                                                <DeleteIcon />
+                                            </IconButton>
+                                        </Tooltip>
+                                    </TableCell>
+                                </TableRow>
+                            ))}
+                        </TableBody>
+                    </Table>
+                </TableContainer>
+            </CardContent>
+        </Card>
+    );
+}

--- a/src/pages/vmDetails.tsx
+++ b/src/pages/vmDetails.tsx
@@ -4,10 +4,11 @@ import { getVmDetails, getSpiceConnection } from '../services/virtualization';
 import { SpiceViewer } from '../components/vm/SpiceViewer';
 import type { VmStats } from '../types/vm.types';
 
-import { Box, Card, CardContent, CardHeader} from '@mui/material';
+import { Box, Card, CardContent, CardHeader } from '@mui/material';
 import Grid from '@mui/material/Grid2';
 import DisplaySettingsIcon from '@mui/icons-material/DisplaySettings';
-import VmMetrics from '../components/vm/VmMetrics';  // Nur noch default import
+import VmMetrics from '../components/vm/VmMetrics';  
+import VmSnapshots from '../components/vm/VmSnapshots';  
 
 export default function VmDetailsPage() {
     const { vmName } = useParams<{ vmName: string }>();
@@ -60,12 +61,17 @@ export default function VmDetailsPage() {
                         />
                         <CardContent>
                             <SpiceViewer
-                                host={spiceConnection.host} 
+                                host={spiceConnection.host}
                                 port={spiceConnection.wsPort}
                             />
                         </CardContent>
                     </Card>
                 </Grid>
+
+                <Grid size={{ xs: 12 }}>
+                    <VmSnapshots vmName={vmName!} />
+                </Grid>
+
             </Grid>
         </Box>
     );

--- a/src/services/virtualization.ts
+++ b/src/services/virtualization.ts
@@ -417,3 +417,37 @@ export const deleteVmSnapshot = async (vmName: string, snapshotName: string): Pr
         return handleApiError(error as ApiError);
     }
 };
+
+
+export const createVmSnapshot = async (vmName: string, data: { name: string; description?: string }): Promise<VmActionResponse> => {
+    const token = localStorage.getItem('jwt_token');
+    
+    if (!token) {
+        throw new Error('Kein Auth-Token gefunden');
+    }
+    
+    try {
+        const response = await fetch(`/api/virt/domain/${vmName}/snapshot/create`, {
+            method: 'POST',
+            headers: {
+                'Authorization': `Bearer ${token}`,
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify(data)
+        });
+
+        if (!response.ok) {
+            throw {
+                status: response.status,
+                statusText: response.statusText
+            };
+        }
+
+        return await response.json();
+    } catch (error) {
+        if (error instanceof Error) {
+            throw error;
+        }
+        return handleApiError(error as ApiError);
+    }
+};

--- a/src/services/virtualization.ts
+++ b/src/services/virtualization.ts
@@ -4,15 +4,15 @@ import { ApiError } from '@interfaces/api.types';
 import { VmStatusResponse, VmFormData, VmActionResponse, VmStats } from '@interfaces/vm.types';
 
 /**
- * Holt die Liste aller virtuellen Maschinen vom Backend
- * @throws Error wenn die Anfrage fehlschlägt oder der Token fehlt
- * @returns Array von VMs mit Name und Status
+ * Fetches the list of all virtual machines from the backend
+ * @throws Error when the request fails or the token is missing
+ * @returns Array of VMs with name and status
  */
 export const getVirtualMachines = async (): Promise<VMResponse[]> => {
     const token = localStorage.getItem('jwt_token');
     
     if (!token) {
-        throw new Error('Kein Auth-Token gefunden');
+        throw new Error('No auth token found');
     }
     
     try {
@@ -36,22 +36,22 @@ export const getVirtualMachines = async (): Promise<VMResponse[]> => {
         if (error instanceof Error) {
             throw error;
         }
-        // Type Assertion für den API Error
+        // Type Assertion for the API Error
         return handleApiError(error as ApiError);
     }
     
 };
 
 /**
- * Holt den Status aller virtuellen Maschinen vom Backend
- * @throws Error wenn die Anfrage fehlschlägt oder der Token fehlt
- * @returns 
+ * Fetches the status of all virtual machines from the backend
+ * @throws Error when the request fails or the token is missing
+ * @returns Status information for all VMs
  */
 export const getVirtualMachineStatus = async (): Promise<VmStatusResponse> => {
     const token = localStorage.getItem('jwt_token');
     
     if (!token) {
-        throw new Error('Kein Auth-Token gefunden');
+        throw new Error('No auth token found');
     }
     
     try {
@@ -74,17 +74,21 @@ export const getVirtualMachineStatus = async (): Promise<VmStatusResponse> => {
         if (error instanceof Error) {
             throw error;
         }
-        // Type Assertion für den API Error
+        // Type Assertion for the API Error
         return handleApiError(error as ApiError);
     }
 }
 
-
+/**
+ * Creates a new virtual machine
+ * @param vmData Form data containing virtual machine configuration
+ * @returns Boolean indicating success
+ */
 export const createVirtualMachine = async (vmData: VmFormData): Promise<boolean> => {
     const token = localStorage.getItem('jwt_token');
     
     if (!token) {
-        throw new Error('Kein Auth-Token gefunden');
+        throw new Error('No auth token found');
     }
     
     try {
@@ -116,15 +120,16 @@ export const createVirtualMachine = async (vmData: VmFormData): Promise<boolean>
 
 
 /**
- * Startet eine virtuelle Maschine
- * @param name Name der VM
- * @throws Error wenn die Anfrage fehlschlägt
+ * Starts a virtual machine
+ * @param name Name of the VM
+ * @throws Error when the request fails
+ * @returns Promise with the response from the VM action
  */
 export const startVirtualMachine = async (name: string): Promise<VmActionResponse> => {
     const token = localStorage.getItem('jwt_token');
     
     if (!token) {
-        throw new Error('Kein Auth-Token gefunden');
+        throw new Error('No auth token found');
     }
     
     try {
@@ -153,15 +158,16 @@ export const startVirtualMachine = async (name: string): Promise<VmActionRespons
 };
 
 /**
- * Stoppt eine virtuelle Maschine
- * @param name Name der VM
- * @param force Wenn true, wird die VM hart gestoppt
+ * Stops a virtual machine
+ * @param name Name of the VM
+ * @param force If true, the VM will be hard stopped
+ * @returns Promise with the response from the VM action
  */
 export const stopVirtualMachine = async (name: string, force = false): Promise<VmActionResponse> => {
     const token = localStorage.getItem('jwt_token');
     
     if (!token) {
-        throw new Error('Kein Auth-Token gefunden');
+        throw new Error('No auth token found');
     }
     
     try {
@@ -191,14 +197,15 @@ export const stopVirtualMachine = async (name: string, force = false): Promise<V
 };
 
 /**
- * Startet eine virtuelle Maschine neu
- * @param name Name der VM
+ * Reboots a virtual machine
+ * @param name Name of the VM
+ * @returns Promise with the response from the VM action
  */
 export const rebootVirtualMachine = async (name: string): Promise<VmActionResponse> => {
     const token = localStorage.getItem('jwt_token');
     
     if (!token) {
-        throw new Error('Kein Auth-Token gefunden');
+        throw new Error('No auth token found');
     }
     
     try {
@@ -227,15 +234,16 @@ export const rebootVirtualMachine = async (name: string): Promise<VmActionRespon
 };
 
 /**
- * Löscht eine virtuelle Maschine
- * @param name Name der VM
- * @param deleteVhd Wenn true, werden auch die VHD-Dateien gelöscht
+ * Deletes a virtual machine
+ * @param name Name of the VM
+ * @param deleteVhd If true, the VHD files will also be deleted
+ * @returns Promise with the response from the VM action
  */
 export const deleteVirtualMachine = async (name: string, deleteVhd = false): Promise<VmActionResponse> => {
     const token = localStorage.getItem('jwt_token');
     
     if (!token) {
-        throw new Error('Kein Auth-Token gefunden');
+        throw new Error('No auth token found');
     }
     
     try {
@@ -265,14 +273,15 @@ export const deleteVirtualMachine = async (name: string, deleteVhd = false): Pro
 };
 
 /**
- * Holt detaillierte Informationen zu einer virtuellen Maschine
- * @param vmName Name der VM
+ * Fetches detailed information about a virtual machine
+ * @param vmName Name of the VM
+ * @returns Promise with VM statistics
  */
 export const getVmDetails = async (vmName: string): Promise<VmStats> => {
     const token = localStorage.getItem('jwt_token');
     
     if (!token) {
-        throw new Error('Kein Auth-Token gefunden');
+        throw new Error('No auth token found');
     }
     
     try {
@@ -299,7 +308,11 @@ export const getVmDetails = async (vmName: string): Promise<VmStats> => {
     }
 };
 
-
+/**
+ * Gets SPICE connection details for a virtual machine
+ * @param vmName Name of the VM
+ * @returns Connection details including ports and host
+ */
 export const getSpiceConnection = async (vmName: string): Promise<{
     spicePort: number;
     wsPort: number;
@@ -308,7 +321,7 @@ export const getSpiceConnection = async (vmName: string): Promise<{
     const token = localStorage.getItem('jwt_token');
     
     if (!token) {
-        throw new Error('Kein Auth-Token gefunden');
+        throw new Error('No auth token found');
     }
     
     try {
@@ -335,10 +348,10 @@ export const getSpiceConnection = async (vmName: string): Promise<{
     }
 };
 
-
 /**
- * Holt alle Snapshots einer VM
- * @param vmName Name der virtuellen Maschine
+ * Fetches all snapshots of a VM
+ * @param vmName Name of the virtual machine
+ * @returns Promise with snapshot information
  */
 export const getVmSnapshots = async (vmName: string): Promise<{
     vm: string;
@@ -353,7 +366,7 @@ export const getVmSnapshots = async (vmName: string): Promise<{
     const token = localStorage.getItem('jwt_token');
     
     if (!token) {
-        throw new Error('Kein Auth-Token gefunden');
+        throw new Error('No auth token found');
     }
     
     try {
@@ -380,17 +393,17 @@ export const getVmSnapshots = async (vmName: string): Promise<{
     }
 };
 
-
 /**
- * Löscht einen Snapshot einer VM
- * @param vmName Name der VM
- * @param snapshotName Name des Snapshots
+ * Deletes a snapshot of a VM
+ * @param vmName Name of the VM
+ * @param snapshotName Name of the snapshot
+ * @returns Promise with the response from the VM action
  */
 export const deleteVmSnapshot = async (vmName: string, snapshotName: string): Promise<VmActionResponse> => {
     const token = localStorage.getItem('jwt_token');
     
     if (!token) {
-        throw new Error('Kein Auth-Token gefunden');
+        throw new Error('No auth token found');
     }
     
     try {
@@ -418,12 +431,17 @@ export const deleteVmSnapshot = async (vmName: string, snapshotName: string): Pr
     }
 };
 
-
+/**
+ * Creates a snapshot for a virtual machine
+ * @param vmName Name of the VM
+ * @param data Object containing snapshot details (name and optional description)
+ * @returns Promise with the response from the VM action
+ */
 export const createVmSnapshot = async (vmName: string, data: { name: string; description?: string }): Promise<VmActionResponse> => {
     const token = localStorage.getItem('jwt_token');
     
     if (!token) {
-        throw new Error('Kein Auth-Token gefunden');
+        throw new Error('No auth token found');
     }
     
     try {
@@ -434,6 +452,44 @@ export const createVmSnapshot = async (vmName: string, data: { name: string; des
                 'Content-Type': 'application/json',
             },
             body: JSON.stringify(data)
+        });
+
+        if (!response.ok) {
+            throw {
+                status: response.status,
+                statusText: response.statusText
+            };
+        }
+
+        return await response.json();
+    } catch (error) {
+        if (error instanceof Error) {
+            throw error;
+        }
+        return handleApiError(error as ApiError);
+    }
+};
+
+/**
+ * Reverts a VM to a specific snapshot
+ * @param vmName Name of the VM
+ * @param snapshotName Name of the snapshot to revert to
+ * @returns Promise with the response from the VM action
+ */
+export const revertVmSnapshot = async (vmName: string, snapshotName: string): Promise<VmActionResponse> => {
+    const token = localStorage.getItem('jwt_token');
+    
+    if (!token) {
+        throw new Error('No auth token found');
+    }
+    
+    try {
+        const response = await fetch(`/api/virt/domain/${vmName}/snapshot/${snapshotName}/revert`, {
+            method: 'POST',
+            headers: {
+                'Authorization': `Bearer ${token}`,
+                'Content-Type': 'application/json',
+            }
         });
 
         if (!response.ok) {

--- a/src/services/virtualization.ts
+++ b/src/services/virtualization.ts
@@ -379,3 +379,41 @@ export const getVmSnapshots = async (vmName: string): Promise<{
         return handleApiError(error as ApiError);
     }
 };
+
+
+/**
+ * Löscht einen Snapshot einer VM
+ * @param vmName Name der VM
+ * @param snapshotName Name des Snapshots
+ */
+export const deleteVmSnapshot = async (vmName: string, snapshotName: string): Promise<VmActionResponse> => {
+    const token = localStorage.getItem('jwt_token');
+    
+    if (!token) {
+        throw new Error('Kein Auth-Token gefunden');
+    }
+    
+    try {
+        const response = await fetch(`/api/virt/domain/${vmName}/snapshot/${snapshotName}/delete`, {
+            method: 'POST',
+            headers: {
+                'Authorization': `Bearer ${token}`,
+                'Content-Type': 'application/json',
+            }
+        });
+
+        if (!response.ok) {
+            throw {
+                status: response.status,
+                statusText: response.statusText
+            };
+        }
+
+        return await response.json();
+    } catch (error) {
+        if (error instanceof Error) {
+            throw error;
+        }
+        return handleApiError(error as ApiError);
+    }
+};

--- a/src/services/virtualization.ts
+++ b/src/services/virtualization.ts
@@ -334,3 +334,48 @@ export const getSpiceConnection = async (vmName: string): Promise<{
         return handleApiError(error as ApiError);
     }
 };
+
+
+/**
+ * Holt alle Snapshots einer VM
+ * @param vmName Name der virtuellen Maschine
+ */
+export const getVmSnapshots = async (vmName: string): Promise<{
+    vm: string;
+    snapshots: Array<{
+        name: string;
+        creationTime: string;
+        state: string;
+        description: string;
+        parent: string | null;
+    }>;
+}> => {
+    const token = localStorage.getItem('jwt_token');
+    
+    if (!token) {
+        throw new Error('Kein Auth-Token gefunden');
+    }
+    
+    try {
+        const response = await fetch(`/api/virt/domain/${vmName}/snapshots`, {
+            headers: {
+                'Authorization': `Bearer ${token}`,
+                'Content-Type': 'application/json',
+            }
+        });
+
+        if (!response.ok) {
+            throw {
+                status: response.status,
+                statusText: response.statusText
+            };
+        }
+
+        return await response.json();
+    } catch (error) {
+        if (error instanceof Error) {
+            throw error;
+        }
+        return handleApiError(error as ApiError);
+    }
+};


### PR DESCRIPTION
This pull request includes significant changes to the `VmSnapshots` component and various service functions. The changes mainly involve adding a new component for managing VM snapshots and translating comments in the service functions from German to English.

### New Component for VM Snapshots:

* [`src/components/vm/VmSnapshots.tsx`](diffhunk://#diff-1b12f952c62582f052f37508837908b3c7daed1d126237d9a1790a28477f0736R1-R372): Added a new component `VmSnapshots` for managing VM snapshots, including functionalities to create, delete, and revert snapshots with appropriate dialogs and feedback mechanisms.

### Integration of VmSnapshots Component:

* [`src/pages/vmDetails.tsx`](diffhunk://#diff-116f55d43f280f9f42924afd133fa60a0646f3738055e1c4e48ab3ddfd4a8431L10-R11): Integrated the new `VmSnapshots` component into the `VmDetailsPage` to display and manage snapshots for a specific VM. [[1]](diffhunk://#diff-116f55d43f280f9f42924afd133fa60a0646f3738055e1c4e48ab3ddfd4a8431L10-R11) [[2]](diffhunk://#diff-116f55d43f280f9f42924afd133fa60a0646f3738055e1c4e48ab3ddfd4a8431R70-R74)

### Translation of Comments:

* [`src/services/virtualization.ts`](diffhunk://#diff-ab48a16a1555af6ac341aab2a655c025527186b80a4abde216d55b95a9ced5dbL7-R15): Translated all comments from German to English for better readability and consistency. This includes functions like `getVirtualMachines`, `getVirtualMachineStatus`, `createVirtualMachine`, `startVirtualMachine`, `stopVirtualMachine`, `rebootVirtualMachine`, `deleteVirtualMachine`, `getVmDetails`, and `getSpiceConnection`. [[1]](diffhunk://#diff-ab48a16a1555af6ac341aab2a655c025527186b80a4abde216d55b95a9ced5dbL7-R15) [[2]](diffhunk://#diff-ab48a16a1555af6ac341aab2a655c025527186b80a4abde216d55b95a9ced5dbL39-R54) [[3]](diffhunk://#diff-ab48a16a1555af6ac341aab2a655c025527186b80a4abde216d55b95a9ced5dbL77-R91) [[4]](diffhunk://#diff-ab48a16a1555af6ac341aab2a655c025527186b80a4abde216d55b95a9ced5dbL119-R132) [[5]](diffhunk://#diff-ab48a16a1555af6ac341aab2a655c025527186b80a4abde216d55b95a9ced5dbL156-R170) [[6]](diffhunk://#diff-ab48a16a1555af6ac341aab2a655c025527186b80a4abde216d55b95a9ced5dbL194-R208) [[7]](diffhunk://#diff-ab48a16a1555af6ac341aab2a655c025527186b80a4abde216d55b95a9ced5dbL230-R246) [[8]](diffhunk://#diff-ab48a16a1555af6ac341aab2a655c025527186b80a4abde216d55b95a9ced5dbL268-R284) [[9]](diffhunk://#diff-ab48a16a1555af6ac341aab2a655c025527186b80a4abde216d55b95a9ced5dbL302-R315) [[10]](diffhunk://#diff-ab48a16a1555af6ac341aab2a655c025527186b80a4abde216d55b95a9ced5dbL311-R324)